### PR TITLE
Justin dev

### DIFF
--- a/client/src/components/Forum/Postform.js
+++ b/client/src/components/Forum/Postform.js
@@ -7,7 +7,7 @@ const Postform = () => {
         <form>
         <div className="mb-3">
           <label htmlFor="Textarea1" className="form-label">
-            Your Post
+            Post Subject:
           </label>
           <textarea
             className="form-control"
@@ -30,7 +30,7 @@ const Postform = () => {
         {/* </select> */}
         <div className="mb-3">
           <label for="Textarea2" className="form-label">
-            Your Post's Content
+            Post Content:
           </label>
           <textarea
             className="form-control"

--- a/client/src/components/Forum/index.css
+++ b/client/src/components/Forum/index.css
@@ -22,11 +22,36 @@
     border-radius: 15px;
     color:rgb(187, 187, 187);
     background-color: rgb(38,38,38);
+    box-shadow: 4px 4px 5px rgba(154, 160, 185, 0.26)
+}
+
+/* Form labels */
+.form-label {
+    color: #e8871e;
+}
+
+/* Form textareas */
+.form-control {
+    background: #777777;
+    border-color: #a1a1a1;
+    color: #000000;
+    }
+
+.form-control:focus {
+    background: #777777;
+    color: black;
+    }
+
+#inlineFormCustomSelect {
+    width: 240px;
+    background-color: #777777;
+    border-color: #a1a1a1;
+    color: black;
 }
 
 #postSubmitButton {
     position: relative;
-    top: 30px;
+    top: 5px;
 }
 
 select {
@@ -103,15 +128,12 @@ select {
     font-family: 'Julius Sans One', sans-serif;
     font-weight: 700;
     text-align: center;
-    color:rgb(187, 187, 187);
-}
-
-#inlineFormCustomSelect {
-    width: 240px;
+    /* color:rgb(187, 187, 187); */
+    color: #e8871e; /*Palette orange; matches birds on landing page, which makes for a nice flow IMO*/
 }
 
 #zonePostCards {
-    box-shadow: 0 1px 1px rgba(154,160,185,.05), 0 10px 20px rgba(166,173,201,.2);
+    box-shadow: 4px 2px 3px rgba(154,160,185,.05), 6px 4px 10px rgba(166, 173, 201, 0.404);
     background-color: rgb(38,38,38);
     color:rgb(187, 187, 187);
 }

--- a/client/src/components/LandingPage/index.css
+++ b/client/src/components/LandingPage/index.css
@@ -41,7 +41,7 @@ body {
 
   #frontBirdCard {
     /* background-color: rgba(8, 28, 54, 0.3); */
-    background-color: rgba(58, 58, 58, 0.85);
+    background-color: rgba(33, 44, 33, 0.85);
     color: #dadada;
     filter: drop-shadow(0px 0px 25px #000);
     border: 0px;

--- a/client/src/components/Pagination/index.css
+++ b/client/src/components/Pagination/index.css
@@ -2,6 +2,30 @@ amplify-sign-out {
     position: relative;
 }
 
+.signOutBtn {
+    font-family: 'Secular One', sans-serif;
+    color: #e2dadb;
+    background: #52aa00;
+    border: 5px;
+    border-color: #69d305;
+    border-style: outset;
+    filter:drop-shadow(2px 3px 3px #000000);
+    border-radius: 5px;
+}
+
+.signOutBtn:hover {
+    background: #185306;
+    border:5px;
+    border-color: #227907;
+    border-style: outset;
+    border-radius: 5px;
+    letter-spacing: 1px;
+    -webkit-box-shadow: 0px 5px 40px -10px rgba(0,0,0,0.57);
+    -moz-box-shadow: 0px 5px 40px -10px rgba(0,0,0,0.57);
+    box-shadow: 5px 40px -10px rgba(0,0,0,0.57);
+    transition: all 0.4s ease 0s;
+}
+
 :root {
     --amplify-primary-color: #ff6347;
     --amplify-primary-tint: #ff7359;

--- a/client/src/components/SignUp/AmplifySignIn.js
+++ b/client/src/components/SignUp/AmplifySignIn.js
@@ -46,7 +46,7 @@ const AmpSignIn = () => {
       <AmplifyAuthenticator>
         <div slot="sign-in">
           <AmplifySignIn slot="sign-in">
-          <div slot="secondary-footer-content">You’re unbeleafable &#127804;</div>
+          <div slot="secondary-footer-content">You’re unbeleafable! &#127804;</div>
             <div slot="federated-buttons">
               <AmplifyGoogleButton onClick={AmplifyGoogle} />
               <hr />

--- a/client/src/components/SignUp/SignOutBtn.js
+++ b/client/src/components/SignUp/SignOutBtn.js
@@ -15,7 +15,7 @@ async function signOut() {
 
 return (
 
-    <button className="signOutBtn" onClick={signOut}>Sign Out</button>
+    <button className="signOutBtn" onClick={signOut}>Log Out</button>
 
 )
 }

--- a/client/src/components/SignUp/index.css
+++ b/client/src/components/SignUp/index.css
@@ -27,7 +27,6 @@
     transform: translate(-50%,-50%);
     padding: 12px 48px;
     color: #E8871E;
-    /* color: #ffffff; */
     background: linear-gradient(to right, #50C9CE 0, #82FF9E 10%, #50C9CE 20%);
     background-position: 0;
     -webkit-background-clip: text;
@@ -37,7 +36,6 @@
     animation-fill-mode: forwards;
     -webkit-text-size-adjust: none;
     font-weight: 600;
-    /* font-size: 36px; */
     text-decoration: none;
     white-space: nowrap;
     


### PR DESCRIPTION
Made some styling changes -- not hard-set on any of them. Commit messages indicate most changes; brief summary here for reference:

- Minor adjustment to tips card color for some extra contrast
- Styling added to sign out button
- Sign out button label changed to `Log Out` for consistency with `Log in`
    - _**Note:** I realize not all login buttons say `Log In` but the main login card text says "Log in to your account" and I couldn't figure out how to change that, so, I opted to shift towards changing the auth buttons to Log In / Log Out instead of Sign In / Sign Out. Not opposed to changing it back if someone else can figure out where to change that main login card text._
- Added an exclamation mark to the secondary footer text of the login area for fun (and to add a more positive context to the statement)
- Tweaked styling on forum page
    - Main header text changed to our palette orange for some pop, which I think has some nice congruity with the color of the birds on the landing page
    - Modified form labels to make a little more sense
    - Darkened the form inputs to be less blinding on the darkened background
    - Added dropshadow (drop-glow?) to form area for continuity
    - Reduced intensity of drop-glow on post cards


Again, not hard set on anything that I've changed here; mainly just playing around a bit and liked how things looked with these changes. One other note: I applied the darkened background to ALL textareas with the CSS for the forum page, I think, because I just referenced the form class. If that's undesirable, we can change that to target those specific textarea IDs instead.